### PR TITLE
Remove abstractmethod

### DIFF
--- a/autoregistry/__init__.py
+++ b/autoregistry/__init__.py
@@ -1,8 +1,6 @@
 # Don't manually change, let poetry-dynamic-versioning-plugin handle it.
 __version__ = "0.0.0"
 
-from abc import abstractmethod
-
 from .config import RegistryConfig
 from .exceptions import (
     CannotDeriveNameError,

--- a/docs/source/Overview.rst
+++ b/docs/source/Overview.rst
@@ -13,13 +13,13 @@ it to create a ``Registry`` object.
 Inheritence-Based
 ^^^^^^^^^^^^^^^^^
 Generally, when inheriting ``Registry``, we are defining an interface, and thusly
-an `abstract base class`_. The ``Registry`` class already inherits from ``ABCMeta``,
-so the decorator ``@abstractmethod`` will automatically work with subclasses of ``Registry``.
-For convenience, you can also import the ``@abstractmethod`` decorator from ``autoregistry``.
+an `abstract base class`_. The ``Registry`` class is an instance of ``ABCMeta``,
+so the ``abc`` decorator ``@abstractmethod`` will work with subclasses of ``Registry``.
 
 .. code-block:: python
 
-   from autoregistry import Registry, abstractmethod
+   from abc import abstractmethod
+   from autoregistry import Registry
 
 
    class Pokemon(Registry):

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,6 +1,7 @@
+from abc import abstractmethod
 from dataclasses import dataclass
 
-from autoregistry import Registry, abstractmethod
+from autoregistry import Registry
 
 
 def construct_pokemon_classes(**kwargs):

--- a/tests/test_abc.py
+++ b/tests/test_abc.py
@@ -1,0 +1,84 @@
+from abc import ABC, abstractmethod
+
+import pytest
+
+from autoregistry import Registry
+
+
+def test_abc_undefined_abstractmethod():
+    class Pokemon(Registry):
+        @abstractmethod
+        def attack(self):
+            pass
+
+    class Charmander(Pokemon):
+        def attack(self):
+            return 1
+
+    class Pikachu(Pokemon):
+        pass
+
+    with pytest.raises(TypeError):
+        Pokemon()
+
+    with pytest.raises(TypeError):
+        Pokemon["pikachu"]()
+
+    with pytest.raises(TypeError):
+        Pikachu()
+
+    Charmander()
+
+
+def test_abc_multiple_inheritence_first():
+    """The programmer doesn't know inheritting from ABC is superfluous."""
+
+    class Pokemon(ABC, Registry):
+        @abstractmethod
+        def attack(self):
+            pass
+
+    class Charmander(Pokemon):
+        def attack(self):
+            return 1
+
+    class Pikachu(Pokemon):
+        pass
+
+    with pytest.raises(TypeError):
+        Pokemon()
+
+    with pytest.raises(TypeError):
+        Pokemon["pikachu"]()
+
+    with pytest.raises(TypeError):
+        Pikachu()
+
+    Charmander()
+
+
+def test_abc_multiple_inheritence_last():
+    """The programmer doesn't know inheritting from ABC is superfluous."""
+
+    class Pokemon(Registry, ABC):
+        @abstractmethod
+        def attack(self):
+            pass
+
+    class Charmander(Pokemon):
+        def attack(self):
+            return 1
+
+    class Pikachu(Pokemon):
+        pass
+
+    with pytest.raises(TypeError):
+        Pokemon()
+
+    with pytest.raises(TypeError):
+        Pokemon["pikachu"]()
+
+    with pytest.raises(TypeError):
+        Pikachu()
+
+    Charmander()


### PR DESCRIPTION
Per user feedback, remove `abstractmethod` to reduce confusion.