### PR TITLE
fix config-passing issues with attrs library.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ pytest-cov = ">=3,<5"
 pytest-mock = "^3.7.0"
 pyright = "^1.1.273"
 pytest-pyright = "^0.0.3"
+attrs = "^23.1.0"
 
 [tool.coverage.run]
 branch = true

--- a/tests/test_attrs.py
+++ b/tests/test_attrs.py
@@ -1,0 +1,20 @@
+from attrs import frozen
+
+from autoregistry import Registry
+
+
+def test_attrs_compatability():
+    @frozen
+    class Media(Registry, snake_case=True):
+        name: str
+        year: int
+
+    class Movie(Media):
+        pass
+
+    class MusicVideo(Media):
+        pass
+
+    assert list(Media) == ["movie", "music_video"]
+    assert Media["movie"] == Movie
+    assert Media["music_video"] == MusicVideo


### PR DESCRIPTION
This PR fixes configuration incomaptabilities when `slots=True` is used with the `attrs` library.  `attrs` redefines a class whenever `slots=True`. This leads to autoregistry config parameters inappropriately being overwritten with parenting defaults.