### PR TITLE
Fix Attrs Subclassing

### DIFF
--- a/tests/test_attrs.py
+++ b/tests/test_attrs.py
@@ -3,7 +3,7 @@ from attrs import frozen
 from autoregistry import Registry
 
 
-def test_attrs_compatability():
+def test_attrs_root():
     @frozen
     class Media(Registry, snake_case=True):
         name: str
@@ -18,3 +18,20 @@ def test_attrs_compatability():
     assert list(Media) == ["movie", "music_video"]
     assert Media["movie"] == Movie
     assert Media["music_video"] == MusicVideo
+
+
+def test_attrs_children():
+    @frozen
+    class Media(Registry, snake_case=True):
+        name: str
+        year: int
+
+    @frozen
+    class Movie(Media):
+        director: str
+
+    @frozen
+    class HorrorMovie(Movie):
+        antagonist: str
+
+    assert list(Media) == ["movie", "horror_movie"]

--- a/tests/test_attrs.py
+++ b/tests/test_attrs.py
@@ -35,3 +35,17 @@ def test_attrs_children():
         antagonist: str
 
     assert list(Media) == ["movie", "horror_movie"]
+    assert Media["movie"] is Movie
+    assert Media["horror_movie"] is HorrorMovie
+    assert Movie["horror_movie"] is HorrorMovie
+
+    horror_movie = Media["horror_movie"](
+        name="Nosferatu",
+        year=1922,
+        director="Murnau",
+        antagonist="Count Orlok",
+    )
+    assert (
+        str(horror_movie)
+        == "HorrorMovie(name='Nosferatu', year=1922, director='Murnau', antagonist='Count Orlok')"
+    )


### PR DESCRIPTION
#34 fixed directly subclassing `Registry` when using an `attrs` decorator. This PR fixes subclassing the resulting class when using an `attrs` decorator.