### PR TITLE
When skip=True, use a class's own rules (instead of parents) for name derivation.

### DIFF
--- a/autoregistry/_registry.py
+++ b/autoregistry/_registry.py
@@ -250,11 +250,16 @@ class RegistryMeta(ABCMeta, _DictMixin):
                 new_cls = super().__new__(cls, cls_name, bases, namespace)
                 return new_cls
 
-        # Derive registry name before updating registry config, since a classes own name is
-        # subject to it's parents configuration, not its own.
-        registry_name = registry_config.format(cls_name) if name is None else name
-
-        registry_config.update(config)
+        if skip:
+            # If we're not registering the class, update rules first, then derive name.
+            # This allows for things like suffix changing of a subclass hierarchy.
+            registry_config.update(config)
+            registry_name = registry_config.format(cls_name) if name is None else name
+        else:
+            # If we're registering the class, derive name first, then update rules first.
+            # Typically, a classes own name is subject to it's parents configuration, not its own.
+            registry_name = registry_config.format(cls_name) if name is None else name
+            registry_config.update(config)
 
         namespace["__registry__"] = _Registry(registry_config, name=registry_name)
 

--- a/tests/test_classes_config.py
+++ b/tests/test_classes_config.py
@@ -77,6 +77,25 @@ def test_suffix_yes_strip():
     assert list(Sensor.keys()) == ["oxygen", "temperature"]
 
 
+def test_suffix_skip():
+    class Builder(Registry, suffix="Builder"):
+        pass
+
+    class BarBuilder(Builder):
+        pass
+
+    class FooBuilderA(Builder, skip=True, suffix="BuilderA"):
+        pass
+
+    class FooChildBuilderA(FooBuilderA):
+        pass
+
+    assert list(Builder) == ["bar", "foochild"]
+    assert BarBuilder.__registry__.name == "bar"
+    assert list(FooBuilderA) == ["foochild"]
+    assert FooChildBuilderA.__registry__.name == "foochild"
+
+
 def test_prefix_suffix_yes_strip():
     class Sensor(Registry, prefix="Premium", suffix="Sensor"):
         pass


### PR DESCRIPTION
When defining a class hierarchy, it may be useful to introduce abstract subclasses that follow a different naming convention. Consider the following:

```
class Polygon(Registry, suffix="Polygon"):
    pass
    
class Polygon3D(Polygon, suffix="Polygon3D", skip=True):
    pass
    
class Polygon2D(Polygon3D, suffix="Polygon2D", skip=True):
    # A 2D shape in 3D space is a special case of 3D
    # Satisfies a `isinstance(polygon2d, Polygon3D)` relationship
    pass
    
class RectanglePolygon2D(Polygon2D):
    pass
    
class Cuboid(Polygon3D):
    pass
```

To accomplish this, the following behavior is changed:
* Previously, a class's derived name is unconditionally derived using it's parent's rule-set.
* Now, if `skip=True`, a class's derived name is derived using **it's own rule-set**.