### PR TITLE
don't allow arbitrary keyword config

### DIFF
--- a/autoregistry/config.py
+++ b/autoregistry/config.py
@@ -57,6 +57,8 @@ class RegistryConfig:
         for key, value in new.items():
             if hasattr(self, key):
                 setattr(self, key, value)
+            else:
+                raise TypeError(f"Unexpected configuration value {key}={value}")
 
     def getitem(self, registry: dict, key: str):
         """Key/Value lookup with keysplitting and optional case-insensitivity."""

--- a/tests/test_classes_config.py
+++ b/tests/test_classes_config.py
@@ -4,6 +4,14 @@ from common import construct_pokemon_classes
 from autoregistry import InvalidNameError, Registry
 
 
+def test_typo():
+    # Make sure we catch invalid parameters
+    with pytest.raises(TypeError):
+
+        class Sensor(Registry, asdklfjlk=123):
+            pass
+
+
 def test_case_sensitive():
     Pokemon, Charmander, Pikachu, SurfingPikachu = construct_pokemon_classes(
         case_sensitive=True,

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -21,11 +21,21 @@ def test_registry_config_update():
     config.update(
         {
             "suffix": "test",
-            "not_valid_config_key": None,  # This should be ignored.
         }
     )
 
     assert config.suffix == "test"
+
+
+def test_registry_config_update_invalid_key():
+    config = RegistryConfig()
+    with pytest.raises(TypeError):
+        config.update(
+            {
+                "suffix": "test",
+                "not_valid_config_key": None,  # This should be ignored.
+            }
+        )
 
 
 def test_registry_config_cannot_derive_name():


### PR DESCRIPTION
prevents silent configuration typos like:

```
class Sensor(Registry, asdklfjlk=123):
    pass
```