### PR TITLE
Set item interface

### DIFF
--- a/autoregistry/_registry.py
+++ b/autoregistry/_registry.py
@@ -13,6 +13,7 @@ from .exceptions import (
     InvalidNameError,
     KeyCollisionError,
     ModuleAliasError,
+    RegistryError,
 )
 
 
@@ -146,7 +147,10 @@ class _DictMixin:
         return self.__registry__.config.getitem(self.__registry__, key)
 
     def __setitem__(self, key: str, value: Any):
-        self.__registry__.register(value, key, root=True)
+        if type(self) is RegistryDecorator:
+            self.__registry__.register(value, key, root=True)
+        else:
+            raise RegistryError("Cannot directly setitem on a Registry subclass.")
 
     def __iter__(self) -> Generator[str, None, None]:
         yield from self.__registry__

--- a/autoregistry/_registry.py
+++ b/autoregistry/_registry.py
@@ -145,6 +145,9 @@ class _DictMixin:
     def __getitem__(self, key: str) -> Type:
         return self.__registry__.config.getitem(self.__registry__, key)
 
+    def __setitem__(self, key: str, value: Any):
+        self.__registry__.register(value, key, root=True)
+
     def __iter__(self) -> Generator[str, None, None]:
         yield from self.__registry__
 
@@ -261,6 +264,7 @@ class RegistryMeta(ABCMeta, _DictMixin):
         if namespace["__registry__"].config.redirect:
             for method_name in [
                 "__getitem__",
+                "__setitem__",
                 "__iter__",
                 "__len__",
                 "__contains__",
@@ -306,6 +310,7 @@ class Registry(metaclass=RegistryMeta):
     __call__: Callable
     __contains__: Callable[..., bool]
     __getitem__: Callable[[str], Type]
+    __setitem__: Callable[[str, Any], Type]
     __iter__: Callable
     __len__: Callable[..., int]
     clear: Callable[[], None]

--- a/docs/source/Configuration.rst
+++ b/docs/source/Configuration.rst
@@ -76,6 +76,7 @@ doesn't impact the auto-derived registration key.
 
 ``name`` and ``aliases`` values are **not** subject to configured naming rules and will **not** be modified
 by configurations like ``strip_suffix``.
+Similarly, directly setting a registry element ``my_registry["myfunction"] = myfunction`` is not subject to naming rules.
 However, values are still subject to the ``overwrite`` configuration and will raise ``KeyCollisionError`` if
 ``name`` or ``aliases`` attempts to overwrite an existing entry while ``overwrite=False``.
 Additionally, ``name`` and ``aliases`` may **not** contain a  ``.`` or a ``/`` due to :ref:`Key Splitting`.

--- a/docs/source/Overview.rst
+++ b/docs/source/Overview.rst
@@ -98,6 +98,14 @@ object and use it to decorate functions.
        return 2 * x
 
 
+   # Assigning as you would a dictionary also works
+   def baz(x):
+       return 3 * x
+
+
+   my_registry["baz"] = baz  # The key could be any string.
+
+
    # You can also register classes this way.
    @my_registry
    class Baz:

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -1,6 +1,7 @@
 import pytest
 from common import construct_pokemon_classes
 
+import autoregistry
 from autoregistry import Registry
 
 
@@ -79,6 +80,19 @@ def test_defaults_get():
     assert Pokemon.get("foo") is None
     assert Pokemon.get("foo", "charmander") == Charmander
     assert Pokemon.get("foo", Charmander) == Charmander
+
+
+def test_classes_setitem_exception():
+    """Don't allow setting items for a Registry subclass since it breaks the hierarchy."""
+
+    class Foo(Registry):
+        pass
+
+    def bar():
+        pass
+
+    with pytest.raises(autoregistry.RegistryError):
+        Foo["bar"] = bar
 
 
 def test_multiple_inheritence_last():

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -191,6 +191,27 @@ def test_registry_register_at_creation_single():
     assert list(registry) == ["bar"]
 
 
+def test_registry_dictionary_assign():
+    registry = Registry()
+
+    def bar():
+        pass
+
+    registry["foo"] = bar
+    assert registry["foo"] == bar
+
+
+def test_registry_dictionary_assign_collision():
+    registry = Registry()
+
+    def bar():
+        pass
+
+    registry["foo"] = bar
+    with pytest.raises(autoregistry.KeyCollisionError):
+        registry["foo"] = bar
+
+
 def test_registry_module_alias():
     import fake_module
 


### PR DESCRIPTION
Allows you to add items to a `registry = Registry()` as if it were a dictionary. Doesn't allow you to set items in Registry subclasses, as it would break the recursive Registry (and hierarchy) structure.