### PR TITLE
Allow alias list to contain default/derived/provided name.

### DIFF
--- a/tests/test_classes_config.py
+++ b/tests/test_classes_config.py
@@ -276,6 +276,19 @@ def test_aliases_list():
     assert Sensor["oxygen"] == Sensor["o2"] == Sensor["air"] == Oxygen
 
 
+def test_aliases_list_self_collision():
+    """Having an alias be the same as ``name`` should NOT generate a KeyCollisionError."""
+
+    class Sensor(Registry):
+        pass
+
+    class Oxygen(Sensor, aliases=["oxygen"]):
+        pass
+
+    assert list(Sensor.keys()) == ["oxygen"]
+    assert Sensor["oxygen"] == Oxygen
+
+
 def test_aliases_single_str_invalid():
     class Sensor(Registry):
         pass


### PR DESCRIPTION
It can be useful to perform an action like:

```
class Oxygen(Sensor, aliases=["oxygen", "o2"]):
    pass
```

for more explicitness in some code bases.