### PR TITLE
Duplicate import `KeyCollisionError`

### DIFF
--- a/tests/repeat_import_a.py
+++ b/tests/repeat_import_a.py
@@ -1,0 +1,11 @@
+"""For test_registry_overwrite_no_key_collision_repeated_import()."""
+
+from autoregistry import Registry
+
+
+class MyRegistry(Registry):
+    pass
+
+
+class MyRegistryA(MyRegistry):
+    pass

--- a/tests/repeat_import_b.py
+++ b/tests/repeat_import_b.py
@@ -1,0 +1,7 @@
+"""For test_registry_overwrite_no_key_collision_repeated_import()."""
+
+from repeat_import_a import MyRegistry, MyRegistryA
+
+
+class MyRegistryB(MyRegistry):
+    pass

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -166,6 +166,24 @@ def test_registry_overwrite_key_collision():
             pass
 
 
+def test_registry_overwrite_no_key_collision_repeated_import():
+    """Tests that repeated identical definitions don't trigger a KeyCollisionError.
+
+    Originally reported:
+        https://github.com/BrianPugh/belay/issues/181
+    """
+    from importlib.util import module_from_spec, spec_from_file_location
+
+    spec_a = spec_from_file_location("repeat_import_a", "tests/repeat_import_a.py")
+    spec_b = spec_from_file_location("repeat_import_b", "tests/repeat_import_b.py")
+    assert spec_a
+    assert spec_b
+    module_a = module_from_spec(spec_a)
+    module_b = module_from_spec(spec_b)
+    import repeat_import_a
+    import repeat_import_b
+
+
 def test_registry_register_at_creation():
     import fake_module
 


### PR DESCRIPTION
WIP

Attempt to replicate https://github.com/BrianPugh/belay/issues/181

@jsiverskog can you help me replicate your `KeyCollisionError`? You can see my code snippets below where I tried to replicate it, but it doesn't raise a `KeyCollisionError`.

To setup the environment, run:
```
poetry install
```

Then to execute the tests run
```
poetry run python -m pytest
```

I'm like 90% sure the issue you're seeing is coming from within `autoregistry`, but we also do some metaclass shenanigans in Belay, so if we cannot replicate it here, the issue might actually be in Belay.