### PR TITLE
docs: fix type inheritance in examples

### DIFF
--- a/docs/source/Key Splitting.rst
+++ b/docs/source/Key Splitting.rst
@@ -14,7 +14,7 @@ Consider the following code example:
        pass
 
 
-   class SurfingPikachu(Pokemon):
+   class SurfingPikachu(Pikachu):
        pass
 
 We can naively access the ``SurfingPikachu`` constructor via

--- a/docs/source/Reverse Lookup.rst
+++ b/docs/source/Reverse Lookup.rst
@@ -12,7 +12,7 @@ Consider the following class hierarchy:
        pass
 
 
-   class SurfingPikachu(Pokemon):
+   class SurfingPikachu(Pikachu):
        pass
 
 


### PR DESCRIPTION
The type inheritance in the examples from the documentation seems to be incorrect. This PR fixes the base class of `SurfingPikachu` to `Pikachu` instead of `Pokemon`.