### PR TITLE
Use PyPI trusted publishing in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -9,32 +9,33 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - name: Check out repository
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
-          fetch-depth: 0 # Includes getting tags
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
+          fetch-depth: 0  # Needed for hatch-vcs to get version from git tags
+      - uses: astral-sh/setup-uv@v7
         with:
-          python-version: "3.12"
-          enable-cache: true
-
-      - name: Install dependencies
-        run: uv sync --no-dev
-
-      - name: Build package
-        run: uv build
-
-      - name: Publish package
-        if: github.event_name != 'workflow_dispatch'
-        env:
-          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_TOKEN }}
-        run: uv publish
-
-      - uses: actions/upload-artifact@v4
-        if: always()
+          enable-cache: false
+      - run: uv build
+      - uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist/
+
+  publish:
+    needs: build
+    if: github.event_name != 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    environment:
+      name: pypi
+      url: https://pypi.org/p/autoregistry
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: dist
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@v1.14.0


### PR DESCRIPTION
Split the deploy workflow into separate build and publish jobs. Publishing now uses OIDC trusted publishing via pypa/gh-action-pypi-publish and the `pypi` environment instead of a long-lived PYPI_TOKEN secret.